### PR TITLE
Fix broken TLS decryption due to tlslite-ng changes

### DIFF
--- a/httpreplay/transport.py
+++ b/httpreplay/transport.py
@@ -468,24 +468,25 @@ class _TLSStream(tlslite.tlsrecordlayer.TLSRecordLayer):
         self.client_state = self._recordLayer._pendingWriteState
         return True
 
-    def decrypt(self, state, record_type, buf):
+    def decrypt(self, state, record, buf):
         self._recordLayer._readState = state
         if state.encContext.isBlockCipher:
             return bytes(self._recordLayer._decryptThenMAC(
-                record_type, bytearray(buf)
+                record.type, bytearray(buf)
             ))
         elif state.encContext.isAEAD:
+            # Continue here
             return bytes(self._recordLayer._decryptAndUnseal(
-                record_type, bytearray(buf)
+                record, bytearray(buf)
             ))
         else:
             return bytes(self._recordLayer._decryptStreamThenMAC(
-                record_type, bytearray(buf)
+                record.type, bytearray(buf)
             ))
 
-    def decrypt_server(self, record_type, buf):
+    def decrypt_server(self, record, buf):
         try:
-            return self.decrypt(self.server_state, record_type, buf)
+            return self.decrypt(self.server_state, record, buf)
         except tlslite.errors.TLSBadRecordMAC as e:
             log.warning("Bad MAC record, cannot decrypt server stream. %s", e)
             return b""
@@ -495,9 +496,9 @@ class _TLSStream(tlslite.tlsrecordlayer.TLSRecordLayer):
             )
             return b""
 
-    def decrypt_client(self, record_type, buf):
+    def decrypt_client(self, record, buf):
         try:
-            return self.decrypt(self.client_state, record_type, buf)
+            return self.decrypt(self.client_state, record, buf)
         except tlslite.errors.TLSBadRecordMAC as e:
             log.warning("Bad MAC record, cannot decrypt client stream. %s", e)
             return b""
@@ -622,10 +623,10 @@ class TLSStream(Protocol):
             return
 
         record = self.recv.pop(0)
-        self.tls.decrypt_server(record.type, record.data)
+        self.tls.decrypt_server(record, record.data)
 
         record = self.sent.pop(0)
-        self.tls.decrypt_client(record.type, record.data)
+        self.tls.decrypt_client(record, record.data)
 
         self.state = "stream"
         return True
@@ -635,7 +636,7 @@ class TLSStream(Protocol):
             sent = []
             while self.sent:
                 record = self.sent.pop(0)
-                sent.append(self.tls.decrypt_client(record.type, record.data))
+                sent.append(self.tls.decrypt_client(record, record.data))
 
             recv = []
             while self.recv:
@@ -643,7 +644,7 @@ class TLSStream(Protocol):
 
                 try:
                     recv.append(
-                        self.tls.decrypt_server(record.type, record.data)
+                        self.tls.decrypt_server(record, record.data)
                     )
                 except tlslite.errors.TLSProtocolException:
                     log.info(


### PR DESCRIPTION
This fixes https://github.com/cert-ee/cuckoo3/issues/193.

The newer versions of tlslite-ng changed how _decryptAndUnseal function (from tlslite.recordlayer.RecordLayer) parameters work due to validations related to TLS 1.3 and greater.

This PR "reverse-recursively" change the parameters leading to the function call to "fix" the issue. Since this modifications now send the full record, I also "improved" the function calls.

I don't know if there are any other breakages in the code related to this change, but this seems to be working so far.